### PR TITLE
Uses build number (CFBundleVersion) instead

### DIFF
--- a/MTMigration/MTMigration.m
+++ b/MTMigration/MTMigration.m
@@ -41,7 +41,7 @@
 
 
 + (NSString *)appVersion {
-    return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleVersion"];
 }
 
 + (void) setLastMigrationVersion:(NSString *)version {

--- a/MTMigrationTests/MTMigrationTests-Info.plist
+++ b/MTMigrationTests/MTMigrationTests-Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>1.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
I switched to using the build number since it's more in line with our internal versioning convention.

You might decide to integrate it into master for your own use. If you do so, you might also decide to change the NSUserDefaults keys to enable backwards compatibility.

Another con of CFBundleShortVersionString is that it's localizable, which might cause problems.