### PR TITLE
Specifying 'sdk iphonesimulator' in Travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 language: objective-c
-xcode_sdk: iphonesimulator
+env:
+  - XCODEBUILD_SETTINGS="-sdk iphonesimulator"


### PR DESCRIPTION
I don't know why the usual `xcode_sdk: iphonesimulator` is not working. So, we enforce the iphonesimulator sdk in another way and it works now. 

Proof: https://travis-ci.org/Hecktorzr/MTMigration
