### PR TITLE
Updated NSString constant definitions to follow Cocoa guideliness

### DIFF
--- a/MTMigration/MTMigration.m
+++ b/MTMigration/MTMigration.m
@@ -8,9 +8,8 @@
 
 #import "MTMigration.h"
 
-#define MT_MIGRATION_LAST_VERSION_KEY     @"MTMigration.lastMigrationVersion"
-#define MT_MIGRATION_APP_VERSION_KEY      @"MTMigration.appVersion"
-#define MT_MIGRATION_LAST_APP_VERSION_KEY @"MTMigration.lastAppVersion"
+static NSString * const MTMigrationLastVersionKey      = @"MTMigration.lastMigrationVersion";
+static NSString * const MTMigrationLastAppVersionKey   = @"MTMigration.lastAppVersion";
 
 @implementation MTMigration
 
@@ -58,23 +57,23 @@
 }
 
 + (void) setLastMigrationVersion:(NSString *)version {
-    [[NSUserDefaults standardUserDefaults] setValue:version forKey:MT_MIGRATION_LAST_VERSION_KEY];
+    [[NSUserDefaults standardUserDefaults] setValue:version forKey:MTMigrationLastVersionKey];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 + (NSString *) lastMigrationVersion {
-    NSString *res = [[NSUserDefaults standardUserDefaults] valueForKey:MT_MIGRATION_LAST_VERSION_KEY];
+    NSString *res = [[NSUserDefaults standardUserDefaults] valueForKey:MTMigrationLastVersionKey];
 
     return (res ? res : @"");
 }
 
 + (void)setLastAppVersion:(NSString *)version {
-    [[NSUserDefaults standardUserDefaults] setValue:version forKey:MT_MIGRATION_LAST_APP_VERSION_KEY];
+    [[NSUserDefaults standardUserDefaults] setValue:version forKey:MTMigrationLastAppVersionKey];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 + (NSString *) lastAppVersion {
-    NSString *res = [[NSUserDefaults standardUserDefaults] valueForKey:MT_MIGRATION_LAST_APP_VERSION_KEY];
+    NSString *res = [[NSUserDefaults standardUserDefaults] valueForKey:MTMigrationLastAppVersionKey];
     
     return (res ? res : @"");
 }


### PR DESCRIPTION
Just noticed your latest commit (36aba8) and updated the string constants definitions to follow [Cocoa guidelines](https://developer.apple.com/library/ios/documentation/cocoa/conceptual/codingguidelines/Articles/NamingIvarsAndTypes.html): 

```
In general, don’t use the #define preprocessor command to create constants.
```
