### PR TITLE
Updated SenTests to XCTests.

### DIFF
--- a/MTMigration.xcodeproj/project.pbxproj
+++ b/MTMigration.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		5FD66FC116C4852D00FE15E2 /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 5FD66FC016C4852D00FE15E2 /* Default.png */; };
 		5FD66FC316C4852D00FE15E2 /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 5FD66FC216C4852D00FE15E2 /* Default@2x.png */; };
 		5FD66FC516C4852D00FE15E2 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 5FD66FC416C4852D00FE15E2 /* Default-568h@2x.png */; };
-		5FD66FCD16C4852D00FE15E2 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FD66FCC16C4852D00FE15E2 /* SenTestingKit.framework */; };
 		5FD66FCE16C4852D00FE15E2 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FD66FAE16C4852D00FE15E2 /* UIKit.framework */; };
 		5FD66FCF16C4852D00FE15E2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FD66FB016C4852D00FE15E2 /* Foundation.framework */; };
 		5FD66FD716C4852D00FE15E2 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5FD66FD516C4852D00FE15E2 /* InfoPlist.strings */; };
@@ -48,8 +47,7 @@
 		5FD66FC016C4852D00FE15E2 /* Default.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Default.png; sourceTree = "<group>"; };
 		5FD66FC216C4852D00FE15E2 /* Default@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default@2x.png"; sourceTree = "<group>"; };
 		5FD66FC416C4852D00FE15E2 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
-		5FD66FCB16C4852D00FE15E2 /* MTMigrationTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MTMigrationTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
-		5FD66FCC16C4852D00FE15E2 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
+		5FD66FCB16C4852D00FE15E2 /* MTMigrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MTMigrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5FD66FD416C4852D00FE15E2 /* MTMigrationTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "MTMigrationTests-Info.plist"; sourceTree = "<group>"; };
 		5FD66FD616C4852D00FE15E2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		5FD66FD816C4852D00FE15E2 /* MTMigrationTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTMigrationTests.h; sourceTree = "<group>"; };
@@ -73,7 +71,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5FD66FCD16C4852D00FE15E2 /* SenTestingKit.framework in Frameworks */,
 				5FD66FCE16C4852D00FE15E2 /* UIKit.framework in Frameworks */,
 				5FD66FCF16C4852D00FE15E2 /* Foundation.framework in Frameworks */,
 			);
@@ -96,7 +93,7 @@
 			isa = PBXGroup;
 			children = (
 				5FD66FAB16C4852D00FE15E2 /* MTMigration.app */,
-				5FD66FCB16C4852D00FE15E2 /* MTMigrationTests.octest */,
+				5FD66FCB16C4852D00FE15E2 /* MTMigrationTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -107,7 +104,6 @@
 				5FD66FAE16C4852D00FE15E2 /* UIKit.framework */,
 				5FD66FB016C4852D00FE15E2 /* Foundation.framework */,
 				5FD66FB216C4852D00FE15E2 /* CoreGraphics.framework */,
-				5FD66FCC16C4852D00FE15E2 /* SenTestingKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -193,8 +189,8 @@
 			);
 			name = MTMigrationTests;
 			productName = MTMigrationTests;
-			productReference = 5FD66FCB16C4852D00FE15E2 /* MTMigrationTests.octest */;
-			productType = "com.apple.product-type.bundle";
+			productReference = 5FD66FCB16C4852D00FE15E2 /* MTMigrationTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -398,13 +394,13 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
 					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
+					"$(inherited)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MTMigration/MTMigration-Prefix.pch";
 				INFOPLIST_FILE = "MTMigrationTests/MTMigrationTests-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Debug;
 		};
@@ -415,13 +411,13 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
 					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
+					"$(inherited)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MTMigration/MTMigration-Prefix.pch";
 				INFOPLIST_FILE = "MTMigrationTests/MTMigrationTests-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Release;
 		};

--- a/MTMigration.xcodeproj/xcshareddata/xcschemes/MTMigration.xcscheme
+++ b/MTMigration.xcodeproj/xcshareddata/xcschemes/MTMigration.xcscheme
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "5FD66FCA16C4852D00FE15E2"
-               BuildableName = "MTMigrationTests.octest"
+               BuildableName = "MTMigrationTests.xctest"
                BlueprintName = "MTMigrationTests"
                ReferencedContainer = "container:MTMigration.xcodeproj">
             </BuildableReference>
@@ -58,7 +58,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5FD66FAA16C4852D00FE15E2"
@@ -76,7 +77,8 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5FD66FAA16C4852D00FE15E2"

--- a/MTMigrationTests/MTMigrationTests.h
+++ b/MTMigrationTests/MTMigrationTests.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2013 Mysterious Trousers. All rights reserved.
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface MTMigrationTests : SenTestCase
+@interface MTMigrationTests : XCTestCase
 
 @end

--- a/MTMigrationTests/MTMigrationTests.m
+++ b/MTMigrationTests/MTMigrationTests.m
@@ -13,10 +13,15 @@
 
 @implementation MTMigrationTests
 
+- (void)setUp {
+    
+    [super setUp];
+    [MTMigration reset];
+}
+
 - (void)testMigrationReset
 {
-	[MTMigration reset];
-    
+
     XCTestExpectation *expectingBlock1Run = [self expectationWithDescription:@"Expecting block to be run for version 0.9"];
 	[MTMigration migrateToVersion:@"0.9" block:^{
         [expectingBlock1Run fulfill];
@@ -44,7 +49,6 @@
 
 - (void)testMigratesOnFirstRun
 {
-	[MTMigration reset];
 
     XCTestExpectation *expectationBlockRun = [self expectationWithDescription:@"Should execute migration after reset"];
 	[MTMigration migrateToVersion:@"1.0" block:^{
@@ -56,8 +60,7 @@
 
 - (void)testMigratesOnce
 {
-	[MTMigration reset];
-	
+
     XCTestExpectation *expectationBlockRun = [self expectationWithDescription:@"Expecting block to be run"];
 	[MTMigration migrateToVersion:@"1.0" block:^{
         [expectationBlockRun fulfill];
@@ -72,8 +75,7 @@
 
 - (void)testMigratesPreviousBlocks
 {
-	[MTMigration reset];
-	
+
     XCTestExpectation *expectingBlock1Run = [self expectationWithDescription:@"Expecting block to be run for version 0.9"];
 	[MTMigration migrateToVersion:@"0.9" block:^{
         [expectingBlock1Run fulfill];
@@ -89,8 +91,7 @@
 
 - (void)testMigratesInNaturalSortOrder
 {
-	[MTMigration reset];
-	
+
     XCTestExpectation *expectingBlock1Run = [self expectationWithDescription:@"Expecting block to be run for version 0.9"];
 	[MTMigration migrateToVersion:@"0.9" block:^{
         [expectingBlock1Run fulfill];
@@ -110,8 +111,7 @@
 
 - (void)testRunsApplicationUpdateBlockOnce
 {
-    [MTMigration reset];
-    
+
     XCTestExpectation *expectationBlockRun = [self expectationWithDescription:@"Should only call block once"];
     [MTMigration applicationUpdateBlock:^{
         [expectationBlockRun fulfill];
@@ -126,8 +126,7 @@
 
 - (void)testRunsApplicationUpdateBlockeOnlyOnceWithMultipleMigrations
 {
-	[MTMigration reset];
-	
+
     [MTMigration migrateToVersion:@"0.8" block:^{
 		// Do something
 	}];

--- a/MTMigrationTests/MTMigrationTests.m
+++ b/MTMigrationTests/MTMigrationTests.m
@@ -9,140 +9,125 @@
 #import "MTMigrationTests.h"
 #import "MTMigration.h"
 
+#define kDefaultWaitForExpectionsTimeout 2.0
+
 @implementation MTMigrationTests
-
-- (void)setUp
-{
-    [super setUp];
-    
-    // Set-up code here.
-}
-
-- (void)tearDown
-{
-    // Tear-down code here.
-    
-    [super tearDown];
-}
 
 - (void)testMigrationReset
 {
 	[MTMigration reset];
-	
-	__block NSInteger val = 0;
     
+    XCTestExpectation *expectingBlock1Run = [self expectationWithDescription:@"Expecting block to be run for version 0.9"];
 	[MTMigration migrateToVersion:@"0.9" block:^{
-		val++;
+        [expectingBlock1Run fulfill];
 	}];
     
+    XCTestExpectation *expectingBlock2Run = [self expectationWithDescription:@"Expecting block to be run for version 1.0"];
 	[MTMigration migrateToVersion:@"1.0" block:^{
-		val++;
+        [expectingBlock2Run fulfill];
 	}];
 	
 	[MTMigration reset];
 
+    XCTestExpectation *expectingBlock3Run = [self expectationWithDescription:@"Expecting block to be run AGAIN for version 0.9"];
 	[MTMigration migrateToVersion:@"0.9" block:^{
-		val++;
+        [expectingBlock3Run fulfill];
 	}];
     
+    XCTestExpectation *expectingBlock4Run = [self expectationWithDescription:@"Expecting block to be run AGAIN for version 1.0"];
 	[MTMigration migrateToVersion:@"1.0" block:^{
-		val++;
+        [expectingBlock4Run fulfill];
 	}];
-	
-	STAssertEquals(val, 4, @"Should execute all migrations again after reset");
     
+    [self waitForAllExpectations];
 }
 
 - (void)testMigratesOnFirstRun
 {
 	[MTMigration reset];
-	
-	__block NSInteger val = 0;
-	
+
+    XCTestExpectation *expectationBlockRun = [self expectationWithDescription:@"Should execute migration after reset"];
 	[MTMigration migrateToVersion:@"1.0" block:^{
-		val = 1;
+        [expectationBlockRun fulfill];
 	}];
 	
-	STAssertEquals(val, 1, @"Should execute migration after reset");
-	
+    [self waitForAllExpectations];
 }
 
 - (void)testMigratesOnce
 {
 	[MTMigration reset];
 	
-	__block NSInteger val = 0;
-	
+    XCTestExpectation *expectationBlockRun = [self expectationWithDescription:@"Expecting block to be run"];
 	[MTMigration migrateToVersion:@"1.0" block:^{
+        [expectationBlockRun fulfill];
 	}];
 	
 	[MTMigration migrateToVersion:@"1.0" block:^{
-		val = 1;
+        XCTFail(@"Should not execute a block for the same version twice.");
 	}];
 	
-	STAssertEquals(val, 0, @"Should not execute a block for the same version twice.");
-	
+    [self waitForAllExpectations];
 }
 
 - (void)testMigratesPreviousBlocks
 {
 	[MTMigration reset];
 	
-	__block NSInteger val = 0;
-	
+    XCTestExpectation *expectingBlock1Run = [self expectationWithDescription:@"Expecting block to be run for version 0.9"];
 	[MTMigration migrateToVersion:@"0.9" block:^{
-		val++;
+        [expectingBlock1Run fulfill];
 	}];
 	
+    XCTestExpectation *expectingBlock2Run = [self expectationWithDescription:@"Expecting block to be run for version 1.0"];
 	[MTMigration migrateToVersion:@"1.0" block:^{
-		val++;
+        [expectingBlock2Run fulfill];
 	}];
 	
-	STAssertEquals(val, 2, @"Should execute any migrations that have not run yet");
-	
+    [self waitForAllExpectations];
 }
 
 - (void)testMigratesInNaturalSortOrder
 {
 	[MTMigration reset];
 	
-	__block NSInteger val = 0;
-	
+    XCTestExpectation *expectingBlock1Run = [self expectationWithDescription:@"Expecting block to be run for version 0.9"];
 	[MTMigration migrateToVersion:@"0.9" block:^{
-		val++;
+        [expectingBlock1Run fulfill];
 	}];
+    
+    [MTMigration migrateToVersion:@"0.1" block:^{
+        XCTFail(@"Should use natural sort order, e.g. treat 0.10 as a follower of 0.9");
+    }];
 	
+    XCTestExpectation *expectingBlock2Run = [self expectationWithDescription:@"Expecting block to be run for version 0.10"];
 	[MTMigration migrateToVersion:@"0.10" block:^{
-		val*=2;
+        [expectingBlock2Run fulfill];
 	}];
 	
-	STAssertEquals(val, 2, @"Should use natural sort order, e.g. treat 0.10 as a follower of 0.9");
-	
+    [self waitForAllExpectations];
 }
 
 - (void)testRunsApplicationUpdateBlockOnce
 {
     [MTMigration reset];
     
-    __block NSInteger val = 0;
-    
+    XCTestExpectation *expectationBlockRun = [self expectationWithDescription:@"Should only call block once"];
     [MTMigration applicationUpdateBlock:^{
-        val++;
+        [expectationBlockRun fulfill];
     }];
     
     [MTMigration applicationUpdateBlock:^{
-        val++;
+        XCTFail(@"Expected applicationUpdateBlock to be called only once");
     }];
     
-    STAssertEquals(val, 1, @"Should only call block once");
+    [self waitForAllExpectations];
 }
 
 - (void)testRunsApplicationUpdateBlockeOnlyOnceWithMultipleMigrations
 {
 	[MTMigration reset];
 	
-	__block NSInteger val = 0;
-    
     [MTMigration migrateToVersion:@"0.8" block:^{
 		// Do something
 	}];
@@ -155,12 +140,19 @@
 		// Do something
 	}];
     
+    XCTestExpectation *expectationBlockRun = [self expectationWithDescription:@"Should call the applicationUpdateBlock only once no matter how many migrations have to be done"];
     [MTMigration applicationUpdateBlock:^{
-        val = 1;
+        [expectationBlockRun fulfill];
     }];
-	
-	STAssertEquals(val, 1, @"Should call the applicationUpdateBlock only once no matter how many migrations have to be done.");
-	
+
+    [self waitForAllExpectations];
+}
+
+- (void)waitForAllExpectations {
+    
+    [self waitForExpectationsWithTimeout:kDefaultWaitForExpectionsTimeout handler:^(NSError *error) {
+        //do nothing
+    }];
 }
 
 @end


### PR DESCRIPTION
Updated SenTests to XCTests using xCode `Convert To XCTests`

Used `XCTestExpectations`, a block testing feature new to XCTest, to better check when or if blocks are being called in the tests.

Removed `__block NSInteger val = 0;` previously used to test blocks.