### PR TITLE
Prevent update block called on first time app installed.

### DIFF
--- a/MTMigration/MTMigration.h
+++ b/MTMigration/MTMigration.h
@@ -45,6 +45,16 @@ typedef void (^MTExecutionBlock)(void);
 + (void) applicationUpdateBlock:(MTExecutionBlock)updateBlock;
 
 /**
+ 
+ Executes a block of code for every time the application version changes.
+ 
+ @param updateBlock A block object to be executed when the application version changes. This parameter can't be nil.
+ @param ignoreFirstInstall Set to YES to not run the updateBlock when no app version is found. This is useful to avoid calling the updateBlock on first time install. Calling with NO, will have same effect as calling applicationUpdateBlock:(MTExecutionBlock)updateBlock;
+ */
+
++ (void) applicationUpdateBlock:(MTExecutionBlock)updateBlock ignoreFirstInstall:(BOOL)ignoreFirstInstall;
+
+/**
 
  Executes a block of code for every time the application build number changes.
 

--- a/MTMigration/MTMigration.m
+++ b/MTMigration/MTMigration.m
@@ -51,13 +51,29 @@ static NSString * const MTMigrationLastAppBuildKey   = @"MTMigration.lastAppBuil
 
 
 + (void) applicationUpdateBlock:(MTExecutionBlock)updateBlock {
-    if (![[self lastAppVersion] isEqualToString:[self appVersion]]) {
-        updateBlock();
+    
+    [self applicationUpdateBlock:updateBlock ignoreFirstInstall:NO];
+}
 
-        #if DEBUG
++ (void) applicationUpdateBlock:(MTExecutionBlock)updateBlock ignoreFirstInstall:(BOOL)ignoreFirstInstall {
+    
+    BOOL lastAppVersionExists = ![[self lastAppVersion] isEqualToString:@""];
+    BOOL performCheck = lastAppVersionExists || !ignoreFirstInstall;
+    
+    if(performCheck) {
+        
+        BOOL appVersionDifferent = ![[self lastAppVersion] isEqualToString:[self appVersion]];
+        if (appVersionDifferent) {
+            updateBlock();
+            
+#if DEBUG
             NSLog(@"MTMigration: Running update Block for version %@", [self appVersion]);
-        #endif
-
+#endif
+            
+            [self setLastAppVersion:[self appVersion]];
+        }
+    } else {
+        
         [self setLastAppVersion:[self appVersion]];
     }
 }

--- a/MTMigrationTests/MTMigrationTests.m
+++ b/MTMigrationTests/MTMigrationTests.m
@@ -8,19 +8,46 @@
 
 #import "MTMigrationTests.h"
 #import "MTMigration.h"
+#import <objc/runtime.h>
 
-#define kDefaultWaitForExpectionsTimeout 2.0
+#define kDefaultWaitForExpectionsTimeout    2.0
+#define kBundleShortVersionStringKey        @"CFBundleShortVersionString"
+#define kBundleVersionKey                   @"CFBundleVersion"
 
 @implementation MTMigrationTests
+
+#define makr - Setup/TearDown
 
 - (void)setUp {
     
     [super setUp];
+    [self setUpMockBundle];
     [MTMigration reset];
 }
 
-- (void)testMigrationReset
-{
+- (void)setUpMockBundle {
+
+    [self swapOutBundleMethods];
+}
+
+- (void)tearDown {
+    
+    [self tearDownMockBundle];
+    [super tearDown];
+}
+
+- (void)tearDownMockBundle {
+    
+    [self swapInBundleMethods];
+    [self setMainBundleAppBuild:nil];
+    [self setMainBundleAppVersion:nil];
+}
+
+#pragma mark - Test migrateToVersion
+
+- (void)testMigrationReset {
+    
+    [self setMainBundleAppVersion:@"1.0"];
 
     XCTestExpectation *expectingBlock1Run = [self expectationWithDescription:@"Expecting block to be run for version 0.9"];
 	[MTMigration migrateToVersion:@"0.9" block:^{
@@ -47,8 +74,9 @@
     [self waitForAllExpectations];
 }
 
-- (void)testMigratesOnFirstRun
-{
+- (void)testMigratesOnFirstRun {
+
+    [self setMainBundleAppVersion:@"1.0"];
 
     XCTestExpectation *expectationBlockRun = [self expectationWithDescription:@"Should execute migration after reset"];
 	[MTMigration migrateToVersion:@"1.0" block:^{
@@ -58,8 +86,9 @@
     [self waitForAllExpectations];
 }
 
-- (void)testMigratesOnce
-{
+- (void)testMigratesOnce {
+
+    [self setMainBundleAppVersion:@"1.0"];
 
     XCTestExpectation *expectationBlockRun = [self expectationWithDescription:@"Expecting block to be run"];
 	[MTMigration migrateToVersion:@"1.0" block:^{
@@ -73,8 +102,17 @@
     [self waitForAllExpectations];
 }
 
-- (void)testMigratesPreviousBlocks
-{
+- (void)testMigrateToVersionWontRunForLowerAppVersions {
+    
+    [self setMainBundleAppVersion:@"0.1"];
+    [MTMigration migrateToVersion:@"1.0" block:^{
+        XCTFail(@"Should not execute a block for the same version twice.");
+    }];
+}
+
+- (void)testMigratesPreviousBlocks {
+
+    [self setMainBundleAppVersion:@"1.0"];
 
     XCTestExpectation *expectingBlock1Run = [self expectationWithDescription:@"Expecting block to be run for version 0.9"];
 	[MTMigration migrateToVersion:@"0.9" block:^{
@@ -92,6 +130,8 @@
 - (void)testMigratesInNaturalSortOrder
 {
 
+    [self setMainBundleAppVersion:@"1.0"];
+    
     XCTestExpectation *expectingBlock1Run = [self expectationWithDescription:@"Expecting block to be run for version 0.9"];
 	[MTMigration migrateToVersion:@"0.9" block:^{
         [expectingBlock1Run fulfill];
@@ -109,9 +149,12 @@
     [self waitForAllExpectations];
 }
 
-- (void)testRunsApplicationUpdateBlockOnce
-{
+#pragma mark - Test applicationUpdateBlock
 
+- (void)testRunsApplicationUpdateBlockOnce {
+
+    [self setMainBundleAppVersion:@"1.0"];
+    
     XCTestExpectation *expectationBlockRun = [self expectationWithDescription:@"Should only call block once"];
     [MTMigration applicationUpdateBlock:^{
         [expectationBlockRun fulfill];
@@ -124,9 +167,10 @@
     [self waitForAllExpectations];
 }
 
-- (void)testRunsApplicationUpdateBlockeOnlyOnceWithMultipleMigrations
-{
+- (void)testRunsApplicationUpdateBlockeOnlyOnceWithMultipleMigrations {
 
+    [self setMainBundleAppVersion:@"1.0"];
+    
     [MTMigration migrateToVersion:@"0.8" block:^{
 		// Do something
 	}];
@@ -147,11 +191,77 @@
     [self waitForAllExpectations];
 }
 
+- (void)testRunsApplicationBlockButIgnoresFirstTimeInstall {
+    
+    [self setMainBundleAppVersion:@"1.0"];
+
+    [MTMigration applicationUpdateBlock:^{
+        XCTFail(@"Expected on first install, this block will never run.");
+    } ignoreFirstInstall:YES];
+
+    [self setMainBundleAppVersion:@"1.1"];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Expect block to be run"];
+    [MTMigration applicationUpdateBlock:^{
+        [expectation fulfill];
+    } ignoreFirstInstall:YES];
+    
+    [self waitForAllExpectations];
+}
+
 - (void)waitForAllExpectations {
     
     [self waitForExpectationsWithTimeout:kDefaultWaitForExpectionsTimeout handler:^(NSError *error) {
         //do nothing
     }];
+}
+
+#pragma mark - Methods used to mock [NSBundle mainBundle] values
+static NSString *mockAppVersion;
+static NSString *mockAppBuild;
+
+- (void)setMainBundleAppVersion:(NSString *)appVersion {
+    mockAppVersion = appVersion;
+}
+
+- (void)setMainBundleAppBuild:(NSString *)appBuild {
+    mockAppBuild = appBuild;
+}
+
+// The following methods use a technique called method swizzling (http://nshipster.com/method-swizzling/) and
+// provide the only way in which the tests can manipulate the application version and build number in our static class
+//
+// In summary, the method `objectForInfoDictionaryKey` is swapped with this class's method `swizzled_objectForInfoDictionaryKey`
+// allowing the test method to intercept this method call and provide appropriate mock responses.
+
+- (void)swapOutBundleMethods {
+    
+    method_exchangeImplementations(class_getInstanceMethod([NSBundle class], @selector(objectForInfoDictionaryKey:)),
+                                   class_getInstanceMethod([MTMigrationTests class], @selector(swizzled_objectForInfoDictionaryKey:)));
+}
+
+- (void)swapInBundleMethods {
+    
+    method_exchangeImplementations(class_getInstanceMethod([MTMigrationTests class], @selector(swizzled_objectForInfoDictionaryKey:)),
+                                   class_getInstanceMethod([NSBundle class], @selector(objectForInfoDictionaryKey:)));
+}
+
+- (id)swizzled_objectForInfoDictionaryKey:(NSString *)key {
+    
+    if ([key isEqualToString:kBundleVersionKey] && mockAppBuild) {
+        
+        return mockAppBuild;
+        
+    } else if ([key isEqualToString:kBundleShortVersionStringKey] && mockAppVersion) {
+        
+        return mockAppVersion;
+        
+    } else {
+        
+        XCTFail(@"Mock bundle is missing a mock key/value pair");
+    }
+    
+    return nil;
 }
 
 @end


### PR DESCRIPTION
Hey, when using your library in our code, we've found the need to ***NOT*** call the `updateBlock` when the application is started from a fresh install. In fact, we've had to code defensively around this case.

I have since forked your code and created a private pod, but thought that this change might be something that you would want.

Being a good citizen I've written unit tests around the new method. I found it difficult to mock/change the application version and build numbers as need for my test. So I used a technique called [method swizzling](http://nshipster.com/method-swizzling/) to properly mock out these values. See it at the bottom of the unit test class.

In addition I added an example test method to show case how much more powerful these tests can be instead of relying on the test project's bundle values. Seemed pretty important as `MTMigration` core is built around these bundle values. 

I hope this all makes sense. Let me know what you think.

Thanks for the pod, very helpful otherwise.