### PR TITLE
Added Swift version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: objective-c
 xcode_project: MTMigration.xcodeproj
 xcode_scheme: MTMigration
+xcode_sdk: iphonesimulator8.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: objective-c
-env:
-  - XCODEBUILD_SETTINGS="-sdk iphonesimulator"
+xcode_project: MTMigration.xcodeproj
+xcode_scheme: MTMigration

--- a/MTMigration.podspec
+++ b/MTMigration.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "MTMigration"
-  s.version      = "0.0.4"
+  s.version      = "0.0.5"
   s.summary      = "Manages blocks of code that only need to run once on version updates in iOS apps."
   s.homepage     = "https://github.com/mysterioustrousers/MTMigration"
   s.license      = 'MIT'

--- a/MTMigrationSwift.podspec
+++ b/MTMigrationSwift.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name         = "MTMigrationSwift"
+  s.version      = "0.0.5"
+  s.summary      = "Manages blocks of code that only need to run once on version updates in iOS apps."
+  s.homepage     = "https://github.com/mysterioustrousers/MTMigration"
+  s.license      = 'MIT'
+  s.author       = { "Parker Wightman" => "parkerwightman@gmail.com" }
+  s.source       = { :git => "https://github.com/mysterioustrousers/MTMigration.git", :tag => "#{s.version}" }
+  s.source_files = 'Swift/MTMigration/Migration.swift'
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.9'
+  s.requires_arc = true
+  s.pod_target_xcconfig = { 'SWIFT_WHOLE_MODULE_OPTIMIZATION' => 'YES',
+                            'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+end

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ ensure that the block of code is only ever run once for that version.
 
 You would want to run this code in your app delegate or similar.
 
+Parallel methods for `migrateToBuild:block:` are also available.
+
 Because MTMigration inspects your *-info.plist file for your actual version number and keeps track of the last migration,
 it will migrate all un-migrated blocks inbetween. For example, let's say you had the following migrations:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 MTMigration
 ===========
 
+[![Build Status](https://travis-ci.org/mysterioustrousers/MTMigration.svg?branch=master)](https://travis-ci.org/mysterioustrousers/MTMigration)
+
 Manages blocks of code that need to run once on version updates in iOS apps. This could be anything from data
 normalization routines, "What's New In This Version" screens, or bug fixes.
 

--- a/Swift/MTMigration.xcodeproj/project.pbxproj
+++ b/Swift/MTMigration.xcodeproj/project.pbxproj
@@ -1,0 +1,402 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		DF3083D21BD7DEC900E9361A /* MTMigration.h in Headers */ = {isa = PBXBuildFile; fileRef = DF3083D11BD7DEC900E9361A /* MTMigration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DF3083D91BD7DEC900E9361A /* MTMigration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DF3083CE1BD7DEC900E9361A /* MTMigration.framework */; settings = {ASSET_TAGS = (); }; };
+		DF3083DE1BD7DEC900E9361A /* MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3083DD1BD7DEC900E9361A /* MigrationTests.swift */; };
+		DF3083E91BD7DF0F00E9361A /* Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF3083E81BD7DF0F00E9361A /* Migration.swift */; settings = {ASSET_TAGS = (); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		DF3083DA1BD7DEC900E9361A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DF3083C51BD7DEC900E9361A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DF3083CD1BD7DEC900E9361A;
+			remoteInfo = MTMigration;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		DF3083CE1BD7DEC900E9361A /* MTMigration.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MTMigration.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DF3083D11BD7DEC900E9361A /* MTMigration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTMigration.h; sourceTree = "<group>"; };
+		DF3083D31BD7DEC900E9361A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DF3083D81BD7DEC900E9361A /* MTMigrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MTMigrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DF3083DD1BD7DEC900E9361A /* MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationTests.swift; sourceTree = "<group>"; };
+		DF3083DF1BD7DEC900E9361A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DF3083E81BD7DF0F00E9361A /* Migration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Migration.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		DF3083CA1BD7DEC900E9361A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DF3083D51BD7DEC900E9361A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DF3083D91BD7DEC900E9361A /* MTMigration.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		DF3083C41BD7DEC900E9361A = {
+			isa = PBXGroup;
+			children = (
+				DF3083D01BD7DEC900E9361A /* MTMigration */,
+				DF3083DC1BD7DEC900E9361A /* MTMigrationTests */,
+				DF3083CF1BD7DEC900E9361A /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		DF3083CF1BD7DEC900E9361A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				DF3083CE1BD7DEC900E9361A /* MTMigration.framework */,
+				DF3083D81BD7DEC900E9361A /* MTMigrationTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		DF3083D01BD7DEC900E9361A /* MTMigration */ = {
+			isa = PBXGroup;
+			children = (
+				DF3083E81BD7DF0F00E9361A /* Migration.swift */,
+				DF3083D11BD7DEC900E9361A /* MTMigration.h */,
+				DF3083D31BD7DEC900E9361A /* Info.plist */,
+			);
+			path = MTMigration;
+			sourceTree = "<group>";
+		};
+		DF3083DC1BD7DEC900E9361A /* MTMigrationTests */ = {
+			isa = PBXGroup;
+			children = (
+				DF3083DD1BD7DEC900E9361A /* MigrationTests.swift */,
+				DF3083DF1BD7DEC900E9361A /* Info.plist */,
+			);
+			path = MTMigrationTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		DF3083CB1BD7DEC900E9361A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DF3083D21BD7DEC900E9361A /* MTMigration.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		DF3083CD1BD7DEC900E9361A /* MTMigration */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DF3083E21BD7DEC900E9361A /* Build configuration list for PBXNativeTarget "MTMigration" */;
+			buildPhases = (
+				DF3083C91BD7DEC900E9361A /* Sources */,
+				DF3083CA1BD7DEC900E9361A /* Frameworks */,
+				DF3083CB1BD7DEC900E9361A /* Headers */,
+				DF3083CC1BD7DEC900E9361A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MTMigration;
+			productName = MTMigration;
+			productReference = DF3083CE1BD7DEC900E9361A /* MTMigration.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		DF3083D71BD7DEC900E9361A /* MTMigrationTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DF3083E51BD7DEC900E9361A /* Build configuration list for PBXNativeTarget "MTMigrationTests" */;
+			buildPhases = (
+				DF3083D41BD7DEC900E9361A /* Sources */,
+				DF3083D51BD7DEC900E9361A /* Frameworks */,
+				DF3083D61BD7DEC900E9361A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DF3083DB1BD7DEC900E9361A /* PBXTargetDependency */,
+			);
+			name = MTMigrationTests;
+			productName = MTMigrationTests;
+			productReference = DF3083D81BD7DEC900E9361A /* MTMigrationTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		DF3083C51BD7DEC900E9361A /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
+				ORGANIZATIONNAME = "Mysterious Trousers";
+				TargetAttributes = {
+					DF3083CD1BD7DEC900E9361A = {
+						CreatedOnToolsVersion = 7.0.1;
+					};
+					DF3083D71BD7DEC900E9361A = {
+						CreatedOnToolsVersion = 7.0.1;
+					};
+				};
+			};
+			buildConfigurationList = DF3083C81BD7DEC900E9361A /* Build configuration list for PBXProject "MTMigration" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = DF3083C41BD7DEC900E9361A;
+			productRefGroup = DF3083CF1BD7DEC900E9361A /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				DF3083CD1BD7DEC900E9361A /* MTMigration */,
+				DF3083D71BD7DEC900E9361A /* MTMigrationTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		DF3083CC1BD7DEC900E9361A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DF3083D61BD7DEC900E9361A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		DF3083C91BD7DEC900E9361A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DF3083E91BD7DF0F00E9361A /* Migration.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DF3083D41BD7DEC900E9361A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DF3083DE1BD7DEC900E9361A /* MigrationTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		DF3083DB1BD7DEC900E9361A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DF3083CD1BD7DEC900E9361A /* MTMigration */;
+			targetProxy = DF3083DA1BD7DEC900E9361A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		DF3083E01BD7DEC900E9361A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		DF3083E11BD7DEC900E9361A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		DF3083E31BD7DEC900E9361A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = MTMigration/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = mystrou.MTMigration.MTMigration;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		DF3083E41BD7DEC900E9361A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = MTMigration/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = mystrou.MTMigration.MTMigration;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		DF3083E61BD7DEC900E9361A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = MTMigrationTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = mystrou.MTMigration.MTMigrationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		DF3083E71BD7DEC900E9361A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = MTMigrationTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = mystrou.MTMigration.MTMigrationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		DF3083C81BD7DEC900E9361A /* Build configuration list for PBXProject "MTMigration" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DF3083E01BD7DEC900E9361A /* Debug */,
+				DF3083E11BD7DEC900E9361A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DF3083E21BD7DEC900E9361A /* Build configuration list for PBXNativeTarget "MTMigration" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DF3083E31BD7DEC900E9361A /* Debug */,
+				DF3083E41BD7DEC900E9361A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DF3083E51BD7DEC900E9361A /* Build configuration list for PBXNativeTarget "MTMigrationTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DF3083E61BD7DEC900E9361A /* Debug */,
+				DF3083E71BD7DEC900E9361A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = DF3083C51BD7DEC900E9361A /* Project object */;
+}

--- a/Swift/MTMigration/Info.plist
+++ b/Swift/MTMigration/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.0.5</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Swift/MTMigration/MTMigration.h
+++ b/Swift/MTMigration/MTMigration.h
@@ -1,0 +1,11 @@
+#import <UIKit/UIKit.h>
+
+//! Project version number for MTMigration.
+FOUNDATION_EXPORT double MTMigrationVersionNumber;
+
+//! Project version string for MTMigration.
+FOUNDATION_EXPORT const unsigned char MTMigrationVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <MTMigration/PublicHeader.h>
+
+

--- a/Swift/MTMigration/Migration.swift
+++ b/Swift/MTMigration/Migration.swift
@@ -47,11 +47,6 @@ public struct Migration {
         self.setLastMigrationVersion(nil)
         self.setLastAppBuild(nil)
         self.setLastMigrationBuild(nil)
-        
-        print("self.lastAppVersion: \(self.lastAppVersion)")
-        print("self.lastMigrationVersion: \(self.lastMigrationVersion)")
-        print("self.lastAppBuild: \(self.lastAppBuild)")
-        print("self.lastMigrationBuild: \(self.lastMigrationBuild)")
     }
     
     // MARK: - Private methods and properties

--- a/Swift/MTMigration/Migration.swift
+++ b/Swift/MTMigration/Migration.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+public typealias ExecutionClosure = () -> Void
+
+private let MigrationLastVersionKey = "Migration.lastMigrationVersion"
+private let MigrationLastAppVersionKey = "Migration.lastAppVersion"
+
+private let MigrationLastBuildKey = "Migration.lastMigrationBuild"
+private let MigrationLastAppBuildKey = "Migration.lastAppBuild"
+
+public struct Migration {
+    
+    static var AppBundle: NSBundle = NSBundle.mainBundle()
+    
+    public static func migrateToVersion(version: String, closure: ExecutionClosure) {
+        if version.compare(self.lastMigrationVersion, options: [.NumericSearch]) == .OrderedDescending &&
+            version.compare(self.appVersion, options: [.NumericSearch]) != .OrderedDescending {
+                closure()
+                self.setLastMigrationVersion(version)
+        }
+    }
+    
+    public static func migrateToBuild(build: String, closure: ExecutionClosure) {
+        if build.compare(self.lastMigrationBuild, options: [.NumericSearch]) == .OrderedDescending &&
+            build.compare(self.appBuild, options: [.NumericSearch]) != .OrderedDescending {
+                closure()
+                self.setLastMigrationBuild(build)
+        }
+    }
+    
+    public static func applicationUpdate(closure: ExecutionClosure) {
+        if self.lastAppVersion != self.appVersion {
+            closure()
+            self.setLastAppVersion(self.appVersion)
+        }
+    }
+    
+    public static func buildNumberUpdate(closure: ExecutionClosure) {
+        if self.lastAppBuild != self.appBuild {
+            closure()
+            self.setLastAppBuild(self.appBuild)
+        }
+    }
+    
+    public static func reset() {
+        self.setLastAppVersion(nil)
+        self.setLastMigrationVersion(nil)
+        self.setLastAppBuild(nil)
+        self.setLastMigrationBuild(nil)
+        
+        print("self.lastAppVersion: \(self.lastAppVersion)")
+        print("self.lastMigrationVersion: \(self.lastMigrationVersion)")
+        print("self.lastAppBuild: \(self.lastAppBuild)")
+        print("self.lastMigrationBuild: \(self.lastMigrationBuild)")
+    }
+    
+    // MARK: - Private methods and properties
+    
+    private static var appVersion: String {
+        return Migration.AppBundle.objectForInfoDictionaryKey("CFBundleShortVersionString") as? String ?? ""
+    }
+    
+    private static var appBuild: String {
+        return Migration.AppBundle.objectForInfoDictionaryKey("CFBundleVersion") as? String ?? ""
+    }
+    
+    private static func setLastMigrationVersion(version: String?) {
+        NSUserDefaults.standardUserDefaults().setValue(version, forKey: MigrationLastVersionKey)
+        NSUserDefaults.standardUserDefaults().synchronize()
+    }
+    
+    private static func setLastMigrationBuild(build: String?) {
+        NSUserDefaults.standardUserDefaults().setValue(build, forKey: MigrationLastBuildKey)
+        NSUserDefaults.standardUserDefaults().synchronize()
+    }
+    
+    private static var lastMigrationVersion: String {
+        return NSUserDefaults.standardUserDefaults().valueForKey(MigrationLastVersionKey) as? String ?? ""
+    }
+    
+    private static var lastMigrationBuild: String {
+        return NSUserDefaults.standardUserDefaults().valueForKey(MigrationLastBuildKey) as? String ?? ""
+    }
+    
+    private static func setLastAppVersion(version: String?) {
+        NSUserDefaults.standardUserDefaults().setValue(version, forKey: MigrationLastAppVersionKey)
+        NSUserDefaults.standardUserDefaults().synchronize()
+    }
+    
+    private static func setLastAppBuild(build: String?) {
+        NSUserDefaults.standardUserDefaults().setValue(build, forKey: MigrationLastAppBuildKey)
+        NSUserDefaults.standardUserDefaults().synchronize()
+    }
+    
+    private static var lastAppVersion: String {
+        return NSUserDefaults.standardUserDefaults().valueForKey(MigrationLastAppVersionKey) as? String ?? ""
+    }
+    
+    private static var lastAppBuild: String {
+        return NSUserDefaults.standardUserDefaults().valueForKey(MigrationLastAppBuildKey) as? String ?? ""
+    }
+}

--- a/Swift/MTMigrationTests/Info.plist
+++ b/Swift/MTMigrationTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Swift/MTMigrationTests/MigrationTests.swift
+++ b/Swift/MTMigrationTests/MigrationTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import MTMigration
+
+class MigrationTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        
+        Migration.reset()
+        
+        let bundles: [NSBundle] = NSBundle.allBundles().filter {
+            return ($0.bundleIdentifier != nil && $0.bundleIdentifier! == "mystrou.MTMigration.MTMigrationTests")
+        }
+        
+        guard let bundle = bundles.first else { XCTFail("No bundle was found."); return }
+        
+        Migration.AppBundle = bundle
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        
+        Migration.reset()
+    }
+    
+    func testMigrationReset() {
+        let expectation1 = self.expectationWithDescription("Expecting block to be run for version 0.9")
+        Migration.migrateToVersion("0.9") { () -> Void in
+            expectation1.fulfill()
+        }
+        
+        let expectation2 = self.expectationWithDescription("Expecting block to be run for version 1.0")
+        Migration.migrateToVersion("1.0") { () -> Void in
+            expectation2.fulfill()
+        }
+        
+        Migration.reset()
+        
+        let expectation3 = self.expectationWithDescription("Expecting block to be run again for version 0.9")
+        Migration.migrateToVersion("0.9") { () -> Void in
+            expectation3.fulfill()
+        }
+        
+        let expectation4 = self.expectationWithDescription("Expecting block to be run again for version 1.0")
+        Migration.migrateToVersion("1.0") { () -> Void in
+            expectation4.fulfill()
+        }
+        
+        self.waitForAllExpectations()
+    }
+    
+    func testMigratesOnFirstRun() {
+        let expectation = self.expectationWithDescription("Should execute migration after reset")
+        Migration.migrateToVersion("1.0") { () -> Void in
+            expectation.fulfill()
+        }
+        
+        self.waitForAllExpectations()
+    }
+    
+    func testMigratesOnce() {
+        let expectation = self.expectationWithDescription("Expecting block to be run")
+        Migration.migrateToVersion("1.0") { () -> Void in
+            expectation.fulfill()
+        }
+        
+        Migration.migrateToVersion("1.0") { () -> Void in
+            XCTFail("Should not execute a block for the same version twice")
+        }
+        
+        self.waitForAllExpectations()
+    }
+    
+    func testMigratesPreviousBlocks() {
+        let expectation1 = self.expectationWithDescription("Expecting block to be run for version 0.9")
+        Migration.migrateToVersion("0.9") { () -> Void in
+            expectation1.fulfill()
+        }
+        
+        let expectation2 = self.expectationWithDescription("Expecting block to be run for version 1.0")
+        Migration.migrateToVersion("1.0") { () -> Void in
+            expectation2.fulfill()
+        }
+        
+        self.waitForAllExpectations()
+    }
+    
+    func testMigratesInNaturalSortOrder() {
+        let expectation1 = self.expectationWithDescription("Expecting block to be run for version 0.9")
+        Migration.migrateToVersion("0.9") { () -> Void in
+            expectation1.fulfill()
+        }
+        
+        Migration.migrateToVersion("0.1") { () -> Void in
+            XCTFail("Should use natural sort order, e.g. treat 0.10 as a follower of 0.9")
+        }
+        
+        let expectation2 = self.expectationWithDescription("Expecting block to be run for version 0.10")
+        Migration.migrateToVersion("0.10") { () -> Void in
+            expectation2.fulfill()
+        }
+        
+        self.waitForAllExpectations()
+    }
+    
+    func testRunsApplicationUpdateBlockOnce() {
+        let expectation = self.expectationWithDescription("Should only call block once")
+        Migration.applicationUpdate { () -> Void in
+            expectation.fulfill()
+        }
+        
+        Migration.applicationUpdate { () -> Void in
+            XCTFail("Expected applicationUpdate to be called only once")
+        }
+        
+        self.waitForAllExpectations()
+    }
+    
+    func testRunsApplicationUpdateBlockeOnlyOnceWithMultipleMigrations() {
+        Migration.migrateToVersion("0.8") { () -> Void in
+            // Do something
+        }
+        
+        Migration.migrateToVersion("0.9") { () -> Void in
+            // Do something
+        }
+        
+        Migration.migrateToVersion("0.10") { () -> Void in
+            // Do something
+        }
+        
+        let expectation = self.expectationWithDescription("Should call the applicationUpdate only once no matter how many migrations have to be done")
+        Migration.applicationUpdate { () -> Void in
+            expectation.fulfill()
+        }
+        
+        self.waitForAllExpectations()
+    }
+    
+    func waitForAllExpectations() {
+        self.waitForExpectationsWithTimeout(2.0) { (error: NSError?) -> Void in
+            if let error = error {
+                print(error)
+            }
+        }
+    }
+    
+}


### PR DESCRIPTION
We have been using MTMigration for quite some time, and during our deep dive into replacing most of our external libraries with Swift versions I figured that this little nifty class (the Swift version is a struct btw) should be converted to Swift instead of us looking for replacements or build our own.

I basically rewrote the class in Swift, with some minor tweaks to work with the language and as a framework.

Have a look and let me know if this is something of interest. I'd be more than happy to fix any issues you see with this version.

Big thanks from the Narrative Team.