### PR TITLE
Fixes a silly documentation warning

### DIFF
--- a/MTMigration/MTMigration.h
+++ b/MTMigration/MTMigration.h
@@ -27,7 +27,7 @@ typedef void (^MTExecutionBlock)(void);
 /**
  Executes a block of code for a specific build number and remembers this build as the latest migration done by MTMigration.
 
- @param buildNumber A string with a specific build number
+ @param build A string with a specific build number
  @param migrationBlock A block object to be executed when the application build matches the string 'build'. This parameter can't be nil.
 
  */


### PR DESCRIPTION
When building with xcode I get this warning

`Parameter 'buildNumber' not found in the function declaration`

And it is just because the documentation parameter name is not the same as the real one, so I updated the doc block param name

