### PR TITLE
Mark migration methods as non escaping

### DIFF
--- a/MTMigration/MTMigration.h
+++ b/MTMigration/MTMigration.h
@@ -22,7 +22,7 @@ typedef void (^MTExecutionBlock)(void);
 
  */
 
-+ (void) migrateToVersion:(NSString *)version block:(MTExecutionBlock)migrationBlock;
++ (void) migrateToVersion:(NSString *)version block:(__attribute__((noescape)) MTExecutionBlock)migrationBlock;
 
 /**
  Executes a block of code for a specific build number and remembers this build as the latest migration done by MTMigration.
@@ -32,7 +32,7 @@ typedef void (^MTExecutionBlock)(void);
 
  */
 
-+ (void) migrateToBuild:(NSString *)build block:(MTExecutionBlock)migrationBlock;
++ (void) migrateToBuild:(NSString *)build block:(__attribute__((noescape)) MTExecutionBlock)migrationBlock;
 
 /**
 
@@ -42,7 +42,7 @@ typedef void (^MTExecutionBlock)(void);
 
  */
 
-+ (void) applicationUpdateBlock:(MTExecutionBlock)updateBlock;
++ (void) applicationUpdateBlock:(__attribute__((noescape)) MTExecutionBlock)updateBlock;
 
 /**
 
@@ -52,7 +52,7 @@ typedef void (^MTExecutionBlock)(void);
 
  */
 
-+ (void) buildNumberUpdateBlock:(MTExecutionBlock)updateBlock;
++ (void) buildNumberUpdateBlock:(__attribute__((noescape)) MTExecutionBlock)updateBlock;
 
 /** Clears the last migration remembered by MTMigration. Causes all migrations to run from the beginning. */
 

--- a/MTMigration/MTMigration.m
+++ b/MTMigration/MTMigration.m
@@ -19,7 +19,7 @@ static NSString * const MTMigrationLastAppBuildKey   = @"MTMigration.lastAppBuil
 @implementation MTMigration
 
 
-+ (void) migrateToVersion:(NSString *)version block:(MTExecutionBlock)migrationBlock {
++ (void) migrateToVersion:(NSString *)version block:(__attribute__((noescape)) MTExecutionBlock)migrationBlock {
     // version > lastMigrationVersion && version <= appVersion
     if ([version compare:[self lastMigrationVersion] options:NSNumericSearch] == NSOrderedDescending &&
         [version compare:[self appVersion] options:NSNumericSearch]           != NSOrderedDescending) {
@@ -34,7 +34,7 @@ static NSString * const MTMigrationLastAppBuildKey   = @"MTMigration.lastAppBuil
 }
 
 
-+ (void) migrateToBuild:(NSString *)build block:(MTExecutionBlock)migrationBlock
++ (void) migrateToBuild:(NSString *)build block:(__attribute__((noescape)) MTExecutionBlock)migrationBlock
 {
     // build > lastMigrationBuild && build <= appVersion
     if ([build compare:[self lastMigrationBuild] options:NSNumericSearch] == NSOrderedDescending &&
@@ -50,7 +50,7 @@ static NSString * const MTMigrationLastAppBuildKey   = @"MTMigration.lastAppBuil
 }
 
 
-+ (void) applicationUpdateBlock:(MTExecutionBlock)updateBlock {
++ (void) applicationUpdateBlock:(__attribute__((noescape)) MTExecutionBlock)updateBlock {
     if (![[self lastAppVersion] isEqualToString:[self appVersion]]) {
         updateBlock();
 
@@ -63,7 +63,7 @@ static NSString * const MTMigrationLastAppBuildKey   = @"MTMigration.lastAppBuil
 }
 
 
-+ (void) buildNumberUpdateBlock:(MTExecutionBlock)updateBlock {
++ (void) buildNumberUpdateBlock:(__attribute__((noescape)) MTExecutionBlock)updateBlock {
     if (![[self lastAppBuild] isEqualToString:[self appBuild]]) {
         updateBlock();
         


### PR DESCRIPTION
Migration methods just check some version number, mark them as non escaping..